### PR TITLE
#7 Avoid follow-up error by validating Hangout/chat URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handle Chat URL detection properly and fix errors like the following (#7):
+  - `TypeError (no implicit conversion of Issue into String` in `listener.rb:281:in escapeHTML`
 
 ## [v0.4.1] 2023-07-27
 ### Fixed

--- a/lib/hangouts_chat/listener.rb
+++ b/lib/hangouts_chat/listener.rb
@@ -134,6 +134,20 @@ module HangoutsChat
       return unless thread and url and issue.save
       return if issue.is_private?
 
+      unless url
+        Rails.logger.debug("ending interacting with google chat because url is #{url}")
+        return
+      end
+      unless url.start_with?("http")
+        Rails.logger.debug("ending interacting with google chat because #{url} does not seem to contain a valid URL")
+        return
+      end
+
+      Rails.logger.info("found google chat ticket to url #{url}")
+      Rails.logger.debug("thread #{thread}")
+      Rails.logger.debug("g. hangout chat url #{Setting.plugin_redmine_hangouts_chat['hangouts_chat_url']}")
+      Rails.logger.debug("g. hangout chat thr #{Setting.plugin_redmine_hangouts_chat['thread']}")
+
       msg = {
         :project_name => issue.project,
         :author => journal.user.to_s,


### PR DESCRIPTION
This PR closes #7 by adding early-exit code along with debug output to avoid follow-up errors in later method calls. These calls will fail HTML escaping because the given msg variable is nil. The original defect cause is an inproper detection whether the ticket belongs to hangout chat or not.